### PR TITLE
Account deletion

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -22,6 +22,10 @@ class TodoForm(FlaskForm):
 class LogoutForm(FlaskForm):
     submit = SubmitField("I'm sure - Logout")
 
+class DeleteAccountForm(FlaskForm):
+    password = StringField(validators=[DataRequired()])
+    confirm = SubmitField("Confirm Account Deletion")
+
 class ReturnForm(FlaskForm):
     submit = SubmitField("Return to Home Page")
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,7 +1,7 @@
 from flask import render_template
 from flask import redirect
 from flask import flash
-from .forms import LoginForm, LogoutForm, TodoForm, ReturnForm, RegisterForm
+from .forms import LoginForm, LogoutForm, TodoForm, ReturnForm, RegisterForm, DeleteAccountForm
 from werkzeug.security import generate_password_hash, check_password_hash
 from .models import User
 from app import myapp_obj
@@ -81,6 +81,24 @@ def logout():
         logout_user()
         return redirect("/")
     return render_template('logout.html', title = 'Logout Confirmation', form = form)
+@myapp_obj.route("/delete", methods=['POST', 'GET'])
+def delete():
+    if not current_user.is_authenticated: 
+        flash("Please log in to the account you want to delete!")
+        return redirect('/')
+    form = DeleteAccountForm()
+    if form.validate_on_submit():
+        user = User.query.filter_by(username=current_user.username).first()
+        if user.check_password(form.password.data): # wrong password
+            logout_user()
+            db.session.delete(user)
+            db.session.commit()
+            flash("Your account has been successfully deleted.")
+            return redirect("/")
+        else:
+            flash("Please enter your correct password and try again!")
+            return redirect("/delete")
+    return render_template('delete.html', title = 'Logout Confirmation', form = form)
 @myapp_obj.route("/register", methods=['GET', 'POST'])
 def register():
     if current_user.is_authenticated: 

--- a/app/templates/delete.html
+++ b/app/templates/delete.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Are you sure you want to delete your account, {{ current_user.username }}?</h1>
+<p>Please type your password into the textbox and press Confirm Account Deletion if you're sure you want to delete your account!</p>
+<form action="" method="post" novalidate>
+    {{form.hidden_tag()}}
+    <p>{{ form.password() }}</p>
+    {%for error in form.password.errors%}
+    <span style="color: red;"> [{{error}}]</span>
+    {% endfor %}
+    <p>{{ form.confirm() }}</p>
+</form>
+{% endblock %}

--- a/app/templates/login_footer.html
+++ b/app/templates/login_footer.html
@@ -1,7 +1,7 @@
 <p>
     {% if current_user.is_authenticated %}
         Hi, {{ current_user.username }}! You are currently logged in.
-        <a href="{{ url_for('logout') }}">Click here to logout.</a>
+        <a href="{{ url_for('logout') }}">Click here to logout,</a> and <a href="{{ url_for('delete') }}">click here to delete your account.</a>
     {% else %}
         You are currently logged out.
 {% endif %}</p>


### PR DESCRIPTION
Implemented account deletion functionality, available at /delete; only deletes account if you confirm by entering your password correctly; logs out user, deletes user's account from the db, and redirects to /
Added a link to /delete in the footer which shows up while logged in
Added a redirect from /delete to / if the user is not logged in
